### PR TITLE
Add static FIRE calculator website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,11 @@
-# FIREcalc-website
+# FIREcalc Website
+
+This is a simple static website that helps you project your retirement savings and FIRE number.
+
+## Features
+
+- **Retirement projection** based on your current net worth, expected market growth, safe withdrawal rate, inflation, monthly contributions and desired annual spending.
+- **Market index performance** table with sample data.
+- **Finance news** section with example articles.
+
+Open `index.html` in a web browser to use the calculator.

--- a/css/style.css
+++ b/css/style.css
@@ -1,0 +1,47 @@
+body {
+  font-family: Arial, sans-serif;
+  margin: 0;
+  padding: 0;
+  background-color: #f4f4f4;
+}
+header {
+  background-color: #333;
+  color: #fff;
+  padding: 1rem;
+  text-align: center;
+}
+section {
+  padding: 1rem;
+  margin: 1rem;
+  background-color: #fff;
+  border-radius: 4px;
+}
+input, select {
+  padding: 0.5rem;
+  margin: 0.5rem 0;
+  width: 100%;
+  box-sizing: border-box;
+}
+button {
+  padding: 0.5rem 1rem;
+  background-color: #28a745;
+  color: #fff;
+  border: none;
+  cursor: pointer;
+}
+button:hover {
+  background-color: #218838;
+}
+#results {
+  font-weight: bold;
+  margin-top: 1rem;
+}
+table {
+  width: 100%;
+  border-collapse: collapse;
+}
+th, td {
+  border: 1px solid #ddd;
+  padding: 0.5rem;
+  text-align: center;
+}

--- a/data/market_data.json
+++ b/data/market_data.json
@@ -1,0 +1,7 @@
+{
+  "indices": [
+    {"name": "S&P 500", "oneDay": 0.5, "oneMonth": 2.0, "ytd": 10.2, "oneYear": 15.3},
+    {"name": "Dow Jones", "oneDay": -0.2, "oneMonth": 1.5, "ytd": 9.0, "oneYear": 12.7},
+    {"name": "NASDAQ", "oneDay": 1.2, "oneMonth": 3.1, "ytd": 15.4, "oneYear": 20.8}
+  ]
+}

--- a/data/news.json
+++ b/data/news.json
@@ -1,0 +1,7 @@
+{
+  "articles": [
+    {"title": "Investing strategies for a volatile market", "url": "#"},
+    {"title": "Understanding the 4% rule for retirement", "url": "#"},
+    {"title": "How inflation impacts your savings", "url": "#"}
+  ]
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>FIRE Calculator</title>
+  <link rel="stylesheet" href="css/style.css">
+</head>
+<body>
+  <header>
+    <h1>FIRE Calculator</h1>
+  </header>
+
+  <section>
+    <h2>Retirement Projection</h2>
+    <label>Current Net Worth: <input type="number" id="net-worth" value="0"></label>
+    <label>Expected Market Growth %: <input type="number" id="growth" value="7"></label>
+    <label>Safe Withdrawal Rate %: <input type="number" id="swr" value="4"></label>
+    <label>Inflation %: <input type="number" id="inflation" value="3"></label>
+    <label>Monthly Contributions: <input type="number" id="contrib" value="0"></label>
+    <label>Desired Annual Spending: <input type="number" id="spending" value="40000"></label>
+    <label>Years to Project: <input type="number" id="years" value="30"></label>
+    <button onclick="calculateFIRE()">Calculate</button>
+    <div id="results"></div>
+  </section>
+
+  <section>
+    <h2>Market Index Performance</h2>
+    <table>
+      <thead>
+        <tr>
+          <th>Index</th><th>1 Day</th><th>1 Month</th><th>YTD</th><th>1 Year</th>
+        </tr>
+      </thead>
+      <tbody id="market-table"></tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Finance News</h2>
+    <ul id="news-list"></ul>
+  </section>
+
+  <script src="js/script.js"></script>
+</body>
+</html>

--- a/js/script.js
+++ b/js/script.js
@@ -1,0 +1,56 @@
+async function loadMarketData() {
+  const res = await fetch('data/market_data.json');
+  const data = await res.json();
+  const table = document.getElementById('market-table');
+  data.indices.forEach(idx => {
+    const row = document.createElement('tr');
+    row.innerHTML = `<td>${idx.name}</td><td>${idx.oneDay}%</td><td>${idx.oneMonth}%</td><td>${idx.ytd}%</td><td>${idx.oneYear}%</td>`;
+    table.appendChild(row);
+  });
+}
+
+async function loadNews() {
+  const res = await fetch('data/news.json');
+  const data = await res.json();
+  const list = document.getElementById('news-list');
+  data.articles.forEach(article => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = article.url;
+    a.textContent = article.title;
+    li.appendChild(a);
+    list.appendChild(li);
+  });
+}
+
+function calculateFIRE() {
+  const netWorth = parseFloat(document.getElementById('net-worth').value) || 0;
+  const growth = parseFloat(document.getElementById('growth').value) / 100 || 0;
+  const swr = parseFloat(document.getElementById('swr').value) / 100 || 0.04;
+  const inflation = parseFloat(document.getElementById('inflation').value) / 100 || 0.03;
+  const contrib = parseFloat(document.getElementById('contrib').value) || 0;
+  const years = parseInt(document.getElementById('years').value, 10) || 30;
+  const spending = parseFloat(document.getElementById('spending').value) || 40000;
+
+  let portfolio = netWorth;
+  let target = spending / swr;
+
+  for (let y = 1; y <= years; y++) {
+    portfolio = portfolio * (1 + growth) + contrib * 12;
+    target = target * (1 + inflation);
+    if (portfolio >= target) {
+      document.getElementById('results').textContent =
+        `You can reach FIRE in ${y} years with a portfolio of $${portfolio.toFixed(2)}.`;
+      return;
+    }
+  }
+
+  document.getElementById('results').textContent =
+    `After ${years} years, projected portfolio is $${portfolio.toFixed(2)}, ` +
+    `but target in inflated dollars is $${target.toFixed(2)}.`;
+}
+
+window.onload = function() {
+  loadMarketData();
+  loadNews();
+};


### PR DESCRIPTION
## Summary
- add sample market data and news
- implement FIRE calculator with inputs for net worth, growth, withdrawal rate, inflation, contributions, spending and years
- style the site and show results

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6872a00c37508324841856c08d3632be