### PR TITLE
Add stock watchlist using Finnhub API

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,8 @@ This is a simple static website that helps you project your retirement savings a
 ## Features
 
 - **Retirement projection** based on your current net worth, expected market growth, safe withdrawal rate, inflation, monthly contributions and desired annual spending.
-- **Market index performance** table with sample data.
+- **Market index performance** pulled from the Finnhub API.
 - **Finance news** section with example articles.
+- **Stock search and watchlist** powered by the Finnhub API.
 
 Open `index.html` in a web browser to use the calculator.

--- a/index.html
+++ b/index.html
@@ -62,10 +62,8 @@
           <thead>
             <tr>
               <th>Index</th>
-              <th>1 Day</th>
-              <th>1 Month</th>
-              <th>YTD</th>
-              <th>1 Year</th>
+              <th>Price</th>
+              <th>Change %</th>
             </tr>
           </thead>
           <tbody id="market-table"></tbody>
@@ -73,11 +71,34 @@
       </div>
     </section>
 
-    <section class="card p-4 mb-4">
-      <h2 class="h4 mb-3">Finance News</h2>
-      <ul id="news-list" class="list-unstyled mb-0"></ul>
-    </section>
-  </main>
+  <section class="card p-4 mb-4">
+    <h2 class="h4 mb-3">Finance News</h2>
+    <ul id="news-list" class="list-unstyled mb-0"></ul>
+  </section>
+
+  <section class="card p-4 mb-4">
+    <h2 class="h4 mb-3">Stock Search</h2>
+    <div class="input-group mb-3">
+      <input type="text" id="ticker-input" class="form-control" placeholder="Ticker (e.g., AAPL)">
+      <button class="btn btn-primary" type="button" onclick="searchTicker()">Search</button>
+    </div>
+    <div id="search-result" class="mb-3"></div>
+    <h3 class="h5">Watchlist</h3>
+    <div class="table-responsive">
+      <table class="table table-striped">
+        <thead>
+          <tr>
+            <th>Ticker</th>
+            <th>Price</th>
+            <th>Change %</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody id="watchlist-table"></tbody>
+      </table>
+    </div>
+  </section>
+</main>
 
   <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"></script>
   <script src="js/script.js"></script>

--- a/js/script.js
+++ b/js/script.js
@@ -1,12 +1,31 @@
+const API_KEY = 'd1p84j1r01qu436d58rgd1p84j1r01qu436d58s0';
+
+async function fetchQuote(symbol) {
+  const res = await fetch(`https://finnhub.io/api/v1/quote?symbol=${symbol}&token=${API_KEY}`);
+  if (!res.ok) {
+    throw new Error('Quote request failed');
+  }
+  return res.json();
+}
+
 async function loadMarketData() {
-  const res = await fetch('data/market_data.json');
-  const data = await res.json();
+  const indices = [
+    { name: 'S&P 500', symbol: 'SPY' },
+    { name: 'Dow Jones', symbol: 'DIA' },
+    { name: 'NASDAQ', symbol: 'QQQ' }
+  ];
   const table = document.getElementById('market-table');
-  data.indices.forEach(idx => {
-    const row = document.createElement('tr');
-    row.innerHTML = `<td>${idx.name}</td><td>${idx.oneDay}%</td><td>${idx.oneMonth}%</td><td>${idx.ytd}%</td><td>${idx.oneYear}%</td>`;
-    table.appendChild(row);
-  });
+  table.innerHTML = '';
+  for (const idx of indices) {
+    try {
+      const quote = await fetchQuote(idx.symbol);
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${idx.name}</td><td>${formatUSD(quote.c)}</td><td>${quote.dp.toFixed(2)}%</td>`;
+      table.appendChild(row);
+    } catch (e) {
+      console.error(e);
+    }
+  }
 }
 
 async function loadNews() {
@@ -61,4 +80,64 @@ function calculateFIRE() {
 window.onload = function() {
   loadMarketData();
   loadNews();
+  renderWatchlist();
 };
+
+async function searchTicker() {
+  const input = document.getElementById('ticker-input');
+  const symbol = input.value.trim().toUpperCase();
+  const resultDiv = document.getElementById('search-result');
+  if (!symbol) {
+    resultDiv.textContent = 'Please enter a ticker symbol';
+    return;
+  }
+  try {
+    const quote = await fetchQuote(symbol);
+    resultDiv.innerHTML = `${symbol}: ${formatUSD(quote.c)} (${quote.dp.toFixed(2)}%) ` +
+      `<button class="btn btn-sm btn-primary ms-2" onclick="addToWatchlist('${symbol}')">Add to Watchlist</button>`;
+  } catch (e) {
+    resultDiv.textContent = 'Ticker not found';
+  }
+}
+
+function getWatchlist() {
+  return JSON.parse(localStorage.getItem('watchlist') || '[]');
+}
+
+function saveWatchlist(list) {
+  localStorage.setItem('watchlist', JSON.stringify(list));
+}
+
+function addToWatchlist(symbol) {
+  const list = getWatchlist();
+  if (!list.includes(symbol)) {
+    list.push(symbol);
+    saveWatchlist(list);
+    renderWatchlist();
+  }
+}
+
+function removeFromWatchlist(symbol) {
+  const list = getWatchlist().filter(s => s !== symbol);
+  saveWatchlist(list);
+  renderWatchlist();
+}
+
+async function renderWatchlist() {
+  const table = document.getElementById('watchlist-table');
+  if (!table) return;
+  table.innerHTML = '';
+  const list = getWatchlist();
+  for (const symbol of list) {
+    try {
+      const quote = await fetchQuote(symbol);
+      const row = document.createElement('tr');
+      row.innerHTML = `<td>${symbol}</td><td>${formatUSD(quote.c)}</td>` +
+        `<td>${quote.dp.toFixed(2)}%</td>` +
+        `<td><button class="btn btn-sm btn-danger" onclick="removeFromWatchlist('${symbol}')">Remove</button></td>`;
+      table.appendChild(row);
+    } catch (e) {
+      console.error(e);
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- connect to Finnhub API for market index data
- allow searching tickers and saving them to a watchlist
- display watchlist with current price and daily change
- document new features in README

## Testing
- `node -v`
- `node -e "require('./js/script.js')"` *(fails: `window is not defined`)*

------
https://chatgpt.com/codex/tasks/task_e_6872a915c5bc8324931df305e6f794c7